### PR TITLE
Declaration `is_const()` returns true if declared with specifier `constexpr`

### DIFF
--- a/src/srcmlcpp/cpp_types/decls_types/cpp_type.py
+++ b/src/srcmlcpp/cpp_types/decls_types/cpp_type.py
@@ -132,7 +132,7 @@ class CppType(CppElementAndComment):
         return name
 
     def is_const(self) -> bool:
-        return "const" in self.specifiers
+        return "const" in self.specifiers or "constexpr" in self.specifiers
 
     def is_static(self) -> bool:
         return "static" in self.specifiers

--- a/src/srcmlcpp/tests/cpp_types/decls_types_test.py
+++ b/src/srcmlcpp/tests/cpp_types/decls_types_test.py
@@ -78,6 +78,11 @@ def test_cpp_type():
     assert cpp_type.typenames == ["unsigned", "int"]
     assert cpp_type.modifiers == ["*", "*"]
 
+    cpp_type = srcmlcpp.srcmlcpp_main.code_to_cpp_type(options, "static constexpr unsigned int")
+    assert cpp_type.is_const()
+    assert cpp_type.is_static()
+    assert cpp_type.typenames == ["unsigned", "int"]
+
     options.functions_api_prefixes = "MY_API"
     cpp_type = srcmlcpp.srcmlcpp_main.code_to_cpp_type(options, "MY_API int &&")
     assert "MY_API" in cpp_type.specifiers


### PR DESCRIPTION
Updated srcmlcpp to check for `constexpr` as well as `const` when determining if a declaration `is_const()`.

Added test as well.

Closes #16 