### PR TITLE
Callback mechanism instead of regex for rv_policy

### DIFF
--- a/src/litgen/internal/adapted_types/adapted_function.py
+++ b/src/litgen/internal/adapted_types/adapted_function.py
@@ -942,7 +942,10 @@ class AdaptedFunction(AdaptedElement):
 
         if (matches_regex_pointer and returns_pointer) or (matches_regex_reference and returns_reference):
             self.return_value_policy = "reference"
-
+        
+        if options.fn_return_force_policy_reference__callback:
+            options.fn_return_force_policy_reference__callback(self)
+            
     def _pydef_fill_call_policy_from_function_comment(self, call_policy_token: str) -> str | None:
         function_comment = self.cpp_element().cpp_element_comments.comments_as_str()
         if call_policy_token in function_comment:

--- a/src/litgen/options.py
+++ b/src/litgen/options.py
@@ -10,6 +10,7 @@ from srcmlcpp import SrcmlcppOptions
 
 from litgen.internal.template_options import TemplateFunctionsOptions, TemplateClassOptions
 from litgen.internal.class_iterable_info import ClassIterablesInfos
+from litgen.internal.adapted_types import AdaptedFunction
 
 
 class BindLibraryType(Enum):
@@ -210,7 +211,10 @@ class LitgenOptions:
     #    See packages/litgen/integration_tests/mylib/include/mylib/return_value_policy_test.h as an example
     fn_return_force_policy_reference_for_pointers__regex: str = ""
     fn_return_force_policy_reference_for_references__regex: str = ""
-
+    # 
+    # The callback provides a flexible way to enforce the reference return policy for functions
+    fn_return_force_policy_reference__callback: Callable[[AdaptedFunction]] | None = None
+    
     # ------------------------------------------------------------------------------
     # Force overload
     # ------------------------------------------------------------------------------

--- a/src/litgen/options.py
+++ b/src/litgen/options.py
@@ -213,7 +213,7 @@ class LitgenOptions:
     fn_return_force_policy_reference_for_references__regex: str = ""
     # 
     # The callback provides a flexible way to enforce the reference return policy for functions
-    fn_return_force_policy_reference__callback: Callable[[AdaptedFunction]] | None = None
+    fn_return_force_policy_reference__callback: Callable[[AdaptedFunction], None] | None = None
     
     # ------------------------------------------------------------------------------
     # Force overload

--- a/src/litgen/options.py
+++ b/src/litgen/options.py
@@ -10,8 +10,6 @@ from srcmlcpp import SrcmlcppOptions
 
 from litgen.internal.template_options import TemplateFunctionsOptions, TemplateClassOptions
 from litgen.internal.class_iterable_info import ClassIterablesInfos
-from litgen.internal.adapted_types import AdaptedFunction
-
 
 class BindLibraryType(Enum):
     pybind11 = 1
@@ -213,7 +211,8 @@ class LitgenOptions:
     fn_return_force_policy_reference_for_references__regex: str = ""
     # 
     # The callback provides a flexible way to enforce the reference return policy for functions
-    fn_return_force_policy_reference__callback: Callable[[AdaptedFunction], None] | None = None
+    # callback takes litgen.internal.adapted_types.AdaptedFunction as the parameter
+    fn_return_force_policy_reference__callback: Callable[[Any], None] | None = None
     
     # ------------------------------------------------------------------------------
     # Force overload

--- a/src/litgen/tests/option_detect_rv_policy.py
+++ b/src/litgen/tests/option_detect_rv_policy.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+from codemanip import code_utils
+import litgen
+
+from srcmlcpp.cpp_types import (
+    CppPublicProtectedPrivate    
+)
+
+def test_reference_marking():
+    """
+    Example of how the callback mechanism could be used in practice to handle reference return policies
+    """
+   
+    def test_custom_reference_detection(func):
+        if not func.return_value_policy:
+            # for all funcdecl members of classes and structures
+            if isinstance(func.cpp_element().parent, CppPublicProtectedPrivate):
+                if hasattr(func.cpp_element(), "return_type") and (
+                        '&' in func.cpp_element().return_type.modifiers or 
+                        '*' in func.cpp_element().return_type.modifiers):
+                    func.return_value_policy = "reference_internal"
+            # not relevant for this test but it shows posibility to apply policy based on filename
+            elif func.cpp_adapted_function.filename and "ref_stuf" in func.cpp_adapted_function.filename:             
+                func.return_value_policy = "reference"
+            elif "ByRef" in func.cpp_adapted_function.function_name: 
+                func.return_value_policy = "reference"
+
+    code = """
+        class MyClass {
+        public:
+            MyClass& setValue(int value) { _value = value; return *this; }
+            int getValue() const { return _value; }
+            AnotherClass& getReferenceObject() { return _referenceObject; }
+
+        private:
+            int _value;
+            AnotherClass _referenceObject;
+        };
+        MyClass& testFunction();
+        MyClass& testFunctionByRef();
+    """
+
+    options = litgen.LitgenOptions()
+    options.fn_return_force_policy_reference__callback = test_custom_reference_detection
+    generated_code = litgen.generate_code(options, code)
+
+    code_utils.assert_are_codes_equal(
+        generated_code.pydef_code,
+        """
+        auto pyClassMyClass =
+            py::class_<MyClass>
+                (m, "MyClass", "")
+            .def(py::init<>()) // implicit default constructor
+            .def("set_value",
+                &MyClass::setValue,
+                py::arg("value"),
+                py::return_value_policy::reference_internal)
+            .def("get_value",
+                &MyClass::getValue)
+            .def("get_reference_object",
+                &MyClass::getReferenceObject, py::return_value_policy::reference_internal)
+            ;
+
+
+        m.def("test_function",
+            testFunction);
+
+        m.def("test_function_by_ref",
+            testFunctionByRef, py::return_value_policy::reference);
+      """,
+    )


### PR DESCRIPTION
The callback mechanism provides greater flexibility than regexps. 
It allows you to easily customize the reference return policy especially in cases where pointer or reference return types require special handling.

I have many setters that return a reference to themselves, and I want to handle them as `reference_internal`. Using regular expressions would make it difficult to distinguish between functions that start with `set` and return a reference, and others that don't.

I think it would be better to replace the regular expressions in the options with callbacks allowing for much more complex rules

I know i can do this using comments in code, but this process is bad if the project has more than 100 classes with their own methods.

```C++
CurrentClass& setValue(uint32_t value) {
    _value = value;
    return *this;
}
uint32_t getValue() const {
    return _value;
}
SomeObject& getObjects() {
    return _objects;
}
```

```Python
def refrenceDetector(func):
    if not func.return_value_policy:
        if isinstance(func.cpp_element().parent, CppPublicProtectedPrivate):
            if hasattr(func.cpp_element(), "return_type") and (
                    '&' in func.cpp_element().return_type.modifiers or 
                    '*' in func.cpp_element().return_type.modifiers):
                func.return_value_policy = "reference_internal"
```

```Python
def my_litgen_options() -> litgen.LitgenOptions: 
    options = litgen.LitgenOptions()
    ...
    options.fn_return_force_policy_reference__callback = refrenceDetector
    return options 
```