### PR TITLE
Fix case when a return value has a ref

### DIFF
--- a/src/litgen/internal/adapt_function_params/apply_all_adapters.py
+++ b/src/litgen/internal/adapt_function_params/apply_all_adapters.py
@@ -161,7 +161,12 @@ def _make_adapted_lambda_code_end(adapted_function: AdaptedFunction, lambda_adap
 
     # Fill auto_r_equal_or_void
     _fn_return_type = adapted_function.cpp_adapted_function.str_full_return_type()
-    auto_r_equal_or_void = "auto lambda_result = " if _fn_return_type != "void" else ""
+    _return_referenced = False
+
+    if hasattr(adapted_function.cpp_element(), "return_type"):
+        _return_referenced = '&' in adapted_function.cpp_element().return_type.modifiers
+
+    auto_r_equal_or_void = ("auto" + ("&" if _return_referenced else "") + " lambda_result = ") if _fn_return_type != "void" else ""
 
     # Fill function_or_lambda_to_call
     if adapted_function.lambda_to_call is not None:


### PR DESCRIPTION
It fixes the issue of incorrectly generated bindings for methods that have a referenced return value and an array in the parameters at the same time

```C++
    Image& setSignature(const uint8_t signature[20]) {
        memcpy(_signature, signature, sizeof(_signature));
        return *this;
    }
```

```
.def("setSignature",
    [](enma::dex::Image & self, const std::array<uint8_t, 20>& signature) -> enma::dex::Image &
    {
        auto setSignature_adapt_fixed_size_c_arrays = [&self](const std::array<uint8_t, 20>& signature) -> enma::dex::Image &
        {
            auto lambda_result = self.setSignature(signature.data());
            return lambda_result;
        };

        return setSignature_adapt_fixed_size_c_arrays(signature);
    },
    nb::arg("signature")
```
The 'auto' keyword must be emitted with a reference
```
auto& lambda_result = self.setSignature(signature.data());
```