### PR TITLE
Added gil_scoped_release support to functions using a regex as acl

### DIFF
--- a/src/litgen/options.py
+++ b/src/litgen/options.py
@@ -244,6 +244,13 @@ class LitgenOptions:
     fn_force_lambda__regex: RegexOrMatcher = ""
 
     # ------------------------------------------------------------------------------
+    # Add py::call_guard<py::gil_scoped_release>()
+    # ------------------------------------------------------------------------------
+    # Add a GIL release call guard for functions that matches these regexes.
+    # This is useful for long-running C++ functions that don't need to interact with Python objects.
+    fn_add_gil_scoped_release_guard__regex: RegexOrMatcher = ""
+
+    # ------------------------------------------------------------------------------
     # C style buffers to py::array
     # ------------------------------------------------------------------------------
     #

--- a/src/litgen/tests/internal/adapted_types/adapted_function_test.py
+++ b/src/litgen/tests/internal/adapted_types/adapted_function_test.py
@@ -127,6 +127,38 @@ def test_return_policy_regex() -> None:
         """,
     )
 
+def test_gil_scoped_release_py() -> None:
+    options = LitgenOptions()
+    options.bind_library = litgen.BindLibraryType.pybind11
+    options.fn_add_gil_scoped_release_guard__regex = r"^Foo"
+
+    code = """
+    void Foo();
+    """
+    generated_code = LitgenGeneratorTestsHelper.code_to_pydef(options, code)
+    expected_code = """
+        m.def("foo",
+            Foo, py::call_guard<py::gil_scoped_release>());
+        """
+    # logging.warning("\n" + generated_code)
+    code_utils.assert_are_codes_equal(generated_code, expected_code)
+
+def test_gil_scoped_release_nb() -> None:
+    options = LitgenOptions()
+    options.bind_library = litgen.BindLibraryType.nanobind
+    options.fn_add_gil_scoped_release_guard__regex = r"^Foo"
+
+    code = """
+    void Foo();
+    """
+    generated_code = LitgenGeneratorTestsHelper.code_to_pydef(options, code)
+    expected_code = """
+        m.def("foo",
+            Foo, nb::call_guard<nb::gil_scoped_release>());
+        """
+    code_utils.assert_are_codes_equal(generated_code, expected_code)
+
+
 
 def test_implot_one_buffer() -> None:
     options = LitgenOptions()


### PR DESCRIPTION
Added the support of `py::call_guard<py::gil_scoped_release>()` on generated def to fix some edge cases where the gil deadlock when calling a c++ function. In pybind and nanobind, there is the gil_scoped_release directive to handle this.

I implemented `fn_add_gil_scoped_release_guard__regex` to enable the call guards for the functions that needs that.