### PR TITLE
Fix redundant reference to 'c_array_numeric_member_types'

### DIFF
--- a/src/litgen/internal/adapted_types/adapted_class.py
+++ b/src/litgen/internal/adapted_types/adapted_class.py
@@ -93,7 +93,7 @@ class AdaptedClassMember(AdaptedDecl):
             cpp_decl.emit_warning(
                 """
                 AdaptedClassMember: Only numeric C Style arrays are supported
-                Hint: use a vector, or extend `options.c_array_numeric_member_types`
+                Hint: use a vector, or extend `options.member_numeric_c_array_types`
                 """,
                 WarningType.LitgenClassMemberNonNumericCStyleArray,
             )
@@ -137,7 +137,7 @@ class AdaptedClassMember(AdaptedDecl):
             cpp_decl.emit_warning(
                 """
                 AdaptedClassMember: Can't parse the size of this array.
-                Hint: use a vector, or extend `options.c_array_numeric_member_types`
+                Hint: use a vector, or extend `options.member_numeric_c_array_types`
                 """,
                 WarningType.LitgenClassMemberUnparsableSize,
             )

--- a/src/srcmlcpp/scrml_warning_settings.py
+++ b/src/srcmlcpp/scrml_warning_settings.py
@@ -38,7 +38,7 @@ class WarningType(enum.Enum):
     LitgenClassMemberSkipBitfield = enum.auto()
 
     # AdaptedClassMember: Can't parse the size of this array.
-    # Hint: use a vector, or extend `options.c_array_numeric_member_types`
+    # Hint: use a vector, or extend `options.member_numeric_c_array_types`
     LitgenClassMemberUnparsableSize = enum.auto()
 
     # An exception was raised when creating an adapted class member for python


### PR DESCRIPTION
This option has been long renamed to 'member_numeric_c_array_types'.

I had to delve into the sources to know what option to use instead.