### PR TITLE
litgen/internal: Consider types with multi-word name before single-word ones

### DIFF
--- a/src/litgen/internal/cpp_to_python.py
+++ b/src/litgen/internal/cpp_to_python.py
@@ -744,11 +744,23 @@ def standard_type_replacements() -> RegexReplacementList:
     * types translations
     * NULL, nullptr, void translation
     """
+
+    # RegexReplacementList is greedy! Some types like 'unsigned int' need to be
+    # first attempted to be replaced by a conversion targetting also the
+    # 'unsigned' qualifier to prevent errors.
     replacements_str = r"""
     \bunsigned \s*int\b -> int
     \bunsigned \s*short\b -> int
     \bunsigned \s*long long\b -> int
     \bunsigned \s*long\b -> int
+
+    \\blong \s*long\b -> int
+    \blong \s*long\b -> int
+    \blong \s*double\b -> float
+
+    \bconst \s*char*\b -> str
+    \bconst \s*char *\b -> str
+
     \buint8_t\b -> int
     \bint8_t\b -> int
     \buint16_t\b -> int
@@ -759,15 +771,9 @@ def standard_type_replacements() -> RegexReplacementList:
     \bint64_t\b -> int
     \blong\b -> int
     \bshort\b -> int
-    \\blong \s*long\b -> int
-    \blong \s*long\b -> int
 
-    \blong \s*double\b -> float
     \bdouble\b -> float
     \bfloat\b -> float
-
-    \bconst \s*char*\b -> str
-    \bconst \s*char *\b -> str
 
     \bsize_t\b -> int
     \bstd::function<(.*)\((.*)\)> -> Callable[[\2], \1]

--- a/src/litgen/tests/internal/cpp_to_python_test.py
+++ b/src/litgen/tests/internal/cpp_to_python_test.py
@@ -87,6 +87,10 @@ def test_type_to_python() -> None:
         return cpp_to_python.type_to_python(lg_context, s)
 
     assert my_type_to_python("unsigned int") == "int"
+    assert my_type_to_python("unsigned long long") == "int"
+    assert my_type_to_python("long long") == "int"
+    assert my_type_to_python("long double") == "float"
+    assert my_type_to_python("const char") == "str"
     assert my_type_to_python("std::vector<std::optional<int>>") == "List[Optional[int]]"
     assert my_type_to_python("std::optional<std::vector<int>>") == "Optional[List[int]]"
     assert my_type_to_python("std::map<int, std::string>") == "Dict[int, str]"


### PR DESCRIPTION
`RegexReplacement` is greedy which would cause types (due to the order the replacements are in) like 'long long' to be translated into 'int int' instead of just 'int'. This moves the (potentially) problematic types higher in the list and leaves a note for the future.