### PR TITLE
codemanip/amalgamated: Recognize system includes as external

### DIFF
--- a/src/codemanip/amalgamated_header.py
+++ b/src/codemanip/amalgamated_header.py
@@ -84,8 +84,6 @@ def _is_local_include_line(options: AmalgamationOptions, code_line: str) -> bool
     (i.e this will *exclude* lines like "#include <vector>")
     """
     result = False
-    if code_line.startswith(f"#include <{options.local_includes_startwith}"):
-        result = True
     if code_line.startswith(f'#include "{options.local_includes_startwith}'):
         result = True
     return result


### PR DESCRIPTION
According to GCC [0] the syntax "#include <file>" is used for system header files available in system directories and more as set using the '-I' option.

The other syntax "#include "file" is used for application includes as they are first resolved wrt to the location of the current file, then wrt directories as set using the '-iquote' option and then based on the same logic used for system header files.

Based on this definition, I belive the syntax "#include <file>" should be understood as external imports and not internal.

[0] https://gcc.gnu.org/onlinedocs/cpp/Include-Syntax.html